### PR TITLE
Styling/mobile calendar

### DIFF
--- a/pages/calendar.jsx
+++ b/pages/calendar.jsx
@@ -57,7 +57,7 @@ export default function CalendarPage() {
             <p
               className={styles.calendarEntry} 
             >
-              {newEntry.title ? newEntry.title : 'untitled entry'}
+              {newEntry.title ? newEntry.title : 'an untitled entry'}
             </p>
           </div>
         );

--- a/pages/calendar.jsx
+++ b/pages/calendar.jsx
@@ -57,7 +57,7 @@ export default function CalendarPage() {
             <p
               className={styles.calendarEntry} 
             >
-              {newEntry.title ? newEntry.title : 'entry'}
+              {newEntry.title ? newEntry.title : 'untitled entry'}
             </p>
           </div>
         );

--- a/styles/Calendar.module.css
+++ b/styles/Calendar.module.css
@@ -11,10 +11,12 @@
   height: 3.8rem;
   overflow: scroll;
   color: #233E49;
+  transform: translateY(0.5rem);
 }
 
 .calendarEntry::-webkit-scrollbar {
   width: 0.5rem;
+  height: 0.5rem;
 }
 .calendarEntry::-webkit-scrollbar-track {
   background: transparent;

--- a/styles/Calendar.module.css
+++ b/styles/Calendar.module.css
@@ -46,3 +46,9 @@
   box-shadow: rgba(2, 2, 2, 0.2) 3px 3px 0px 1px;
   margin-top: 0.5rem;
 }
+
+@media screen and (max-width: 700px) {
+  .calendarEntry {
+    display: none;
+  }
+}

--- a/styles/Calendar.module.css
+++ b/styles/Calendar.module.css
@@ -8,16 +8,29 @@
   margin-bottom: 0.3rem;
   font-size: 1rem;
   inline-size: 80%;
-  height: 3rem;
-  overflow: hidden;
+  height: 3.8rem;
+  overflow: scroll;
   color: #233E49;
+}
+
+.calendarEntry::-webkit-scrollbar {
+  width: 0.5rem;
+}
+.calendarEntry::-webkit-scrollbar-track {
+  background: transparent;
+}
+.calendarEntry::-webkit-scrollbar-thumb {
+  background-color: #d46b55;
+  border-radius: 20px;
+}
+.calendarEntry::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 .tile {
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100%;
 }
 
 .reactCalendar {
@@ -46,6 +59,7 @@
   box-shadow: rgba(2, 2, 2, 0.2) 3px 3px 0px 1px;
   margin-top: 0.5rem;
 }
+
 
 @media screen and (max-width: 700px) {
   .calendarEntry {

--- a/styles/[pid].module.css
+++ b/styles/[pid].module.css
@@ -49,6 +49,20 @@
   transform: translateY(0.4rem);
 }
 
+.entryText::-webkit-scrollbar {
+  width: 0.8rem;
+}
+.entryText::-webkit-scrollbar-track {
+  background: transparent;
+}
+.entryText::-webkit-scrollbar-thumb {
+  background-color: #d46b55;
+  border-radius: 20px;
+}
+.entryText::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 .headerTitle {
   font-size: 1.3rem;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -78,12 +78,7 @@ a {
 }
 
 .react-calendar__month-view button {
-  /* border: dashed rgba(41, 146, 132, 0.5) 1px; */
   box-shadow:rgba(35, 62, 73, 0.2) 3px 3px 4px 0px;
-}
-
-.react-calendar__month-view__days {
-  /* border: dashed rgba(41, 146, 132, 0.5) 2px; */
 }
 
 .react-calendar__month-view__weekNumbers .react-calendar__tile {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -113,7 +113,7 @@ a {
 }
 
 .react-calendar__tile--now {
-  background: #d46b55;
+  background: rgba(212, 107, 85, 0.5);
 }
 
 .react-calendar__navigation__label {
@@ -130,6 +130,7 @@ a {
   margin: 1rem;
   border-radius: 1rem;
   box-shadow: rgba(2, 2, 2, 0.2) 3px 3px 0px 1px;
+  text-transform:lowercase;
 }
 
 .react-calendar__viewContainer {
@@ -165,4 +166,18 @@ a {
 }
 *::-webkit-scrollbar-corner {
   background: transparent;
+}
+
+@media screen and (max-width: 700px) {
+  .react-calendar__navigation__label__labelText {
+    background-color: transparent;
+    padding: 0px;
+    margin: 0px;
+    box-shadow: none;
+    font-size: 1rem;
+  }
+
+  .react-calendar__tile {
+    height: 4.2rem;
+  }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -154,20 +154,6 @@ a {
   padding: 0.3rem;
 }
 
-*::-webkit-scrollbar {
-  width: 0.8rem;
-}
-*::-webkit-scrollbar-track {
-  background: transparent;
-}
-*::-webkit-scrollbar-thumb {
-  background-color: #d46b55;
-  border-radius: 20px;
-}
-*::-webkit-scrollbar-corner {
-  background: transparent;
-}
-
 @media screen and (max-width: 700px) {
   .react-calendar__navigation__label__labelText {
     background-color: transparent;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -78,11 +78,12 @@ a {
 }
 
 .react-calendar__month-view button {
-  border: dashed rgba(41, 146, 132, 0.5) 1px;
+  /* border: dashed rgba(41, 146, 132, 0.5) 1px; */
+  box-shadow:rgba(35, 62, 73, 0.2) 3px 3px 4px 0px;
 }
 
 .react-calendar__month-view__days {
-  border: dashed rgba(41, 146, 132, 0.5) 2px;
+  /* border: dashed rgba(41, 146, 132, 0.5) 2px; */
 }
 
 .react-calendar__month-view__weekNumbers .react-calendar__tile {


### PR DESCRIPTION
This branch:
- Added mobile responsiveness to the calendar page so it looks nice on mobile as well as desktop.
- Added scroll bars inside of the tiles if the title is too large to view all at once.
- Hides the title text on mobile.
- Changed the borders around the calendar tiles to look a little better with a box-shadow instead.
- Moved the scrollbar styling out of the global file and into the relevant pages so the scrollbars weren't styled across the entire site.